### PR TITLE
allow specifying multiple deliveryMethodOverrides statements

### DIFF
--- a/src/FormHandler.php
+++ b/src/FormHandler.php
@@ -58,7 +58,13 @@ class FormHandler
 
         foreach ($keysToHash as $key) {
             if (isset($this->parameters[$key])) {
-                $base .= $key . '=' . $this->parameters[$key] . '&';
+                 if (! is_array($this->parameters[$key])) {
+                    $base .= $key.'='.$this->parameters[$key].'&';
+                } else {
+                    foreach ($this->parameters[$key] as $entry) {
+                        $base .= $key.'='.$entry.'&';
+                    }
+                }
             }
         }
 
@@ -196,6 +202,9 @@ class FormHandler
             case 'cancelUrl':
             case 'errorUrl':
             default:
+                if (is_array($value)) {
+                    sort($value);
+                }
                 $this->parameters[$key] = $value;
         }
     }


### PR DESCRIPTION
Bpost allows specifying multiple deliveryMethodOverrides

You can now do the following

````php
$formHandler->setParameter('deliveryMethodOverrides', [
    "Pugo|VISIBLE|0",
    "Regular|VISIBLE|0",
])

````

the getChecksum now handles this properly

as a plus:
checksum generation requires parameters to be passed alphabetically by parameterKey when building the string we'll use to hash into our checksum
but when the parameterValue is an array, those actual values need to be sorted too.
since the 

setting an array parameter will now sort those values by default.

so the following would still work

````php
$formHandler->setParameter('deliveryMethodOverrides', [
    "Regular|VISIBLE|0",
    "Pugo|VISIBLE|0",
])

````

If and when merging, can you please bump the version.

thx!

