### PR TITLE
Corrected installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _bpost API library_ is a PHP library which permit to your PHP application to com
 ## Installation
 
 ```bash
-composer install antidot-be/bpost-api-library
+composer require antidot-be/bpost-api-library
 ```
 
 ## Usages


### PR DESCRIPTION
I'm not sure if this worked in the past, but `composer install <package>` is not a valid command in the latest version of composer. Should be `composer require <package>`
