### PR TITLE
Added toArray method on the Poi class to be able to return the entire…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-  "name": "antidot-be/bpost-api-library",
+  "name": "yentel/bpost-api-library",
   "version": "3.4.0",
   "type": "library",
   "description": "bpost API library is a PHP library to communicate with the bpost API.",
-  "homepage": "https://github.com/Antidot-be/bpost-api-library",
+  "homepage": "https://github.com/Yentel/bpost-api-library",
   "license": "BSD",
   "authors": [
     {

--- a/src/Geo6/Poi.php
+++ b/src/Geo6/Poi.php
@@ -354,6 +354,16 @@ class Poi
         $this->page = (string)$page;
     }
 
+    /**
+     * Returns an array of all object variables for read-only purposes.
+     * I.e. returning the Poi object via ajax.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return get_object_vars($this);
+    }
 
     /**
      * Create a POI based on an XML-object


### PR DESCRIPTION
Requesting the Geo getNearestServicePoint or getServicePointDetails returns a Poi object.
This object is fully private and only accessible through getters & setters. This makes it hard to return the Poi object to an ajax request.

Using the toArray function, you can easily return a readonly array of the Poi object to any requester be it ajax or another PHP class without having to reconstruct an object/array yourself using the all getter functions.