### PR TITLE
fix invalid method signature for extended class Bpost/Order/Box/AtHome

### DIFF
--- a/src/Bpost/Order/Box/AtHome.php
+++ b/src/Bpost/Order/Box/AtHome.php
@@ -131,9 +131,11 @@ class AtHome extends National
      * @throws BpostXmlInvalidItemException
      * @throws \Bpost\BpostApiClient\BpostException
      */
-    public static function createFromXML(\SimpleXMLElement $xml)
+    public static function createFromXML(\SimpleXMLElement $xml, $self = null)
     {
-        $self = new self();
+        if ($self === null) {
+            $self = new self();
+        }
 
         if (!isset($xml->atHome)) {
             throw new BpostXmlInvalidItemException();


### PR DESCRIPTION
Please find a fix for issue #11 

I've managed to make the fix and run the unit tests that come with the library. Then I've updated my application to use my patched version and run my tests again in PHP 7.2

Both tests ran perfectly.