### PR TITLE
Header re-initialisation makes calls fail

### DIFF
--- a/src/Bpost.php
+++ b/src/Bpost.php
@@ -218,7 +218,6 @@ class Bpost
     private function doCall($url, $body = null, $headers = array(), $method = 'GET', $expectXML = true)
     {
         // build Authorization header
-        $headers = array();
         $headers[] = 'Authorization: Basic ' . $this->getAuthorizationHeader();
 
         // set options


### PR DESCRIPTION
Header array re-initialisation makes calls fail as incoming headers (from the function) are not passed. 

E.g. the content-type that is passed on from other calls is stripped. Calls are then all resulting in "Cannot consume content type" errors.