### PR TITLE
Fix: Declaration of "classes" must be compatible with National

### DIFF
--- a/src/Bpost/Order/Box/At247.php
+++ b/src/Bpost/Order/Box/At247.php
@@ -298,12 +298,13 @@ class At247 extends National
 
     /**
      * @param  \SimpleXMLElement $xml
+     * @param  National          $self
      *
      * @return At247
      * @throws BpostInvalidValueException
      * @throws BpostNotImplementedException
      */
-    public static function createFromXML(\SimpleXMLElement $xml)
+    public static function createFromXML(\SimpleXMLElement $xml, $self = null)
     {
         $at247 = new At247();
 

--- a/src/Bpost/Order/Box/AtBpost.php
+++ b/src/Bpost/Order/Box/AtBpost.php
@@ -250,12 +250,13 @@ class AtBpost extends National
 
     /**
      * @param  \SimpleXMLElement $xml
+     * @param  National          $self
      *
      * @return AtBpost
      * @throws BpostInvalidValueException
      * @throws BpostNotImplementedException
      */
-    public static function createFromXML(\SimpleXMLElement $xml)
+    public static function createFromXML(\SimpleXMLElement $xml, $self = null)
     {
         $atBpost = new AtBpost();
 

--- a/src/Bpost/Order/Box/AtHome.php
+++ b/src/Bpost/Order/Box/AtHome.php
@@ -126,6 +126,8 @@ class AtHome extends National
 
     /**
      * @param  \SimpleXMLElement $xml
+     * @param  National          $self
+     *
      * @return AtHome
      * @throws BpostNotImplementedException
      * @throws BpostXmlInvalidItemException

--- a/src/Bpost/Order/Box/BpostOnAppointment.php
+++ b/src/Bpost/Order/Box/BpostOnAppointment.php
@@ -105,7 +105,7 @@ class BpostOnAppointment extends National
      * @return BpostOnAppointment
      * @throws BpostXmlInvalidItemException
      */
-    public static function createFromXML(\SimpleXMLElement $xml)
+    public static function createFromXML(\SimpleXMLElement $xml, $self = null)
     {
         $self = new self();
 

--- a/src/Bpost/Order/Box/BpostOnAppointment.php
+++ b/src/Bpost/Order/Box/BpostOnAppointment.php
@@ -101,6 +101,7 @@ class BpostOnAppointment extends National
 
     /**
      * @param  \SimpleXMLElement $xml
+     * @param  National          $self
      * @return BpostOnAppointment
      * @throws BpostXmlInvalidItemException
      */

--- a/src/Bpost/Order/Box/National.php
+++ b/src/Bpost/Order/Box/National.php
@@ -212,7 +212,7 @@ abstract class National extends ComplexAttribute implements IBox
      * @throws BpostException
      * @throws BpostXmlInvalidItemException
      */
-    public static function createFromXML(\SimpleXMLElement $nationalXml, self $self = null)
+    public static function createFromXML(\SimpleXMLElement $nationalXml, $self = null)
     {
         if ($self === null) {
             throw new BpostException('Set an instance of National');

--- a/tests/Bpost/Order/Box/NationalTest.php
+++ b/tests/Bpost/Order/Box/NationalTest.php
@@ -29,9 +29,10 @@ class NationalFake extends National
 
     /**
      * @param  \SimpleXMLElement $xml
+     * @param  National          $self
      * @return self
      */
-    public static function createFromXML(\SimpleXMLElement $xml)
+    public static function createFromXML(\SimpleXMLElement $xml, $self = null)
     {
         return parent::createFromXML($xml->nationalFake, new self());
     }


### PR DESCRIPTION
Fatal error: Declaration of Bpost\BpostApiClient\Bpost\Order\Box\At247::createFromXML(SimpleXMLElement $xml) must be compatible with Bpost\BpostApiClient\Bpost\Order\Box\National::createFromXML(SimpleXMLElement $nationalXml, $self = NULL)