### PR TITLE
Endpoint change for Geo6/Pudo

### DIFF
--- a/src/Geo6.php
+++ b/src/Geo6.php
@@ -18,7 +18,7 @@ use Bpost\BpostApiClient\Geo6\Poi;
 class Geo6
 {
     // URL for the api
-    const API_URL = 'https://taxipost.geo6.be/Locator';
+    const API_URL = 'https://pudo.bpost.be/Locator';
 
     // current version
     const VERSION = '3';


### PR DESCRIPTION
We've received an e-mail that the geo6.be domain will not work anymore, starting Oct 31, 2019
They've switched it over to "pudo.bpost.be". 
Regarding their mailing: excluding the domain change, everything else stays exactly the same. (SSL, Auth, etc.)