### PR TITLE
Fix PHP contraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
     "php": ">=5.3.0",
     "ext-curl": "*",
     "ext-mbstring": "*",
-    "psr/log": "~1.0.0",
+    "psr/log": "^1.0",
     "ext-dom": "20031129",
-    "ext-SimpleXML": "^7.2"
+    "ext-SimpleXML": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8 || ^5.3"


### PR DESCRIPTION
The current constraints, only allow php7.2 projects, but the project is compatible for php5.3 and newer