### PR TITLE
PHP 8: Fixed string/int comparison in ApiCaller

### DIFF
--- a/src/ApiCaller/ApiCaller.php
+++ b/src/ApiCaller/ApiCaller.php
@@ -97,7 +97,7 @@ class ApiCaller
         ));
 
         // error?
-        if ($errorNumber != '') {
+        if ($errorNumber !== 0) {
             throw new BpostCurlException($errorMessage, $errorNumber);
         }
 


### PR DESCRIPTION
I ran into a problem while running this package in PHP 8; because the output of `curl_errno` was compared with a string, all requests would result in a `BpostCurlException`. As far as I know, the return type of `curl_errno` has always been an integer, so this should be backwards compatible.

This seems to be the only fixed required to get it running in PHP 8.