### PR TITLE
curl_errno returns an integer but is tested against an emtpy string that triggers a BpostCurlException in php 8

### DIFF
--- a/src/ApiCaller/ApiCaller.php
+++ b/src/ApiCaller/ApiCaller.php
@@ -97,7 +97,7 @@ class ApiCaller
         ));
 
         // error?
-        if ($errorNumber != '') {
+        if ($errorNumber !== 0) {
             throw new BpostCurlException($errorMessage, $errorNumber);
         }
 


### PR DESCRIPTION
Hi again,

when preparing our production environment for php 8, we noticed unexpected `BpostCurlException`s during our unit test runs. After a quick investigation, the Exception is triggered, because the return value of `curl_errno` is compared against an empty string.

You can verify the documentation here; https://www.php.net/manual/en/function.curl-errno.php