### PR TITLE
fix : XML insurance type's namespace.

### DIFF
--- a/src/Bpost/Order/Box/Option/Insured.php
+++ b/src/Bpost/Order/Box/Option/Insured.php
@@ -166,7 +166,7 @@ class Insured extends Option
      */
     public static function createFromXML(SimpleXMLElement $xml)
     {
-        $insuranceDetail = $xml->children('common', true);
+        $insuranceDetail = $xml->children('ns2', true);
 
         $type = $insuranceDetail->getName();
         $value = $insuranceDetail->attributes()->value !== null ? (int) $insuranceDetail->attributes()->value : null;


### PR DESCRIPTION
bpost-api-library/src/Bpost/Order/Box/Option/Insured.php -> createFromXml()

old namespace : 'common'
new namespace : 'ns2'

XML received: `<ns2:insured><ns2:additionalInsurance value="2"/></ns2:insured>`

