### PR TITLE
Exception code should be integer

### DIFF
--- a/src/Bpack247.php
+++ b/src/Bpack247.php
@@ -132,7 +132,7 @@ class Bpack247
                 && ($xml->getName() == 'businessException' || $xml->getName() == 'systemException')
             ) {
                 $message = (string) $xml->message;
-                $code = isset($xml->code) ? (int) $xml->code : null;
+                $code = isset($xml->code) ? (int) $xml->code : 0;
                 switch ($xml->getName()) {
                     case 'businessException':
                         throw new BpostApiBusinessException($message, $code);

--- a/src/Bpost.php
+++ b/src/Bpost.php
@@ -276,7 +276,7 @@ class Bpost
             ) {
                 // message
                 $message = (string) $xml->error;
-                $code = isset($xml->code) ? (int) $xml->code : null;
+                $code = isset($xml->code) ? (int) $xml->code : 0;
 
                 // throw exception
                 throw new BpostInvalidSelectionException($message, $code);


### PR DESCRIPTION
Passing `null` as exception code is deprecated:

```
Deprecated: Exception::__construct(): Passing null to parameter #2 ($code) of type int is deprecated
```